### PR TITLE
Fix: 가게 데이터 반환 관련 수정 및 user-checker 미들웨어 에러 로직 수정

### DIFF
--- a/src/common/middlewares/user-checker.middleware.ts
+++ b/src/common/middlewares/user-checker.middleware.ts
@@ -1,9 +1,4 @@
-import {
-  HttpException,
-  HttpStatus,
-  Injectable,
-  NestMiddleware,
-} from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { NextFunction, Request, Response } from 'express';
 import { AuthService } from 'src/users/auth/auth.service';
@@ -29,20 +24,7 @@ export class UserCheckerMiddleware implements NestMiddleware {
         });
 
         request.user = user.user;
-      } catch (error: any) {
-        switch (error.name) {
-          case 'TokenExpiredError':
-            throw new HttpException(
-              { message: '토큰이 만료되었습니다.' },
-              HttpStatus.FORBIDDEN,
-            );
-          case 'JsonWebTokenError':
-            throw new HttpException(
-              { message: '토큰이 변조되었습니다.' },
-              HttpStatus.FORBIDDEN,
-            );
-        }
-      }
+      } catch (error: any) {}
     }
 
     next();

--- a/src/likes/likes.repository.ts
+++ b/src/likes/likes.repository.ts
@@ -61,6 +61,7 @@ export class LikesRepository {
     } else {
       return stores.Likes.map((store) => {
         return {
+          storeId: store.Store.storeId,
           ownerId: store.Store.ownerId,
           name: store.Store.name,
           longitude: store.Store.longitude,

--- a/src/likes/likes.repository.ts
+++ b/src/likes/likes.repository.ts
@@ -46,9 +46,8 @@ export class LikesRepository {
         where: { userId },
         select: {
           Likes: {
-            select: {
-              Store: true,
-            },
+            where: { Store: { deletedAt: null } },
+            select: { Store: true },
           },
         },
       });

--- a/src/stores/dto/store.response.dto.ts
+++ b/src/stores/dto/store.response.dto.ts
@@ -4,6 +4,7 @@ import { GetItemDto } from 'src/items/dto/get-item.dto';
 import { StoreEntity } from '../entities/stores.entity';
 
 export class GetStoreResData extends PickType(StoreEntity, [
+  'storeId',
   'ownerId',
   'name',
   'longitude',

--- a/src/stores/stores.repository.ts
+++ b/src/stores/stores.repository.ts
@@ -14,6 +14,7 @@ export class StoresRepository {
         deletedAt: null,
       },
       select: {
+        storeId: true,
         ownerId: true,
         name: true,
         longitude: true,
@@ -35,6 +36,7 @@ export class StoresRepository {
         deletedAt: null,
       },
       select: {
+        storeId: true,
         ownerId: true,
         name: true,
         longitude: true,


### PR DESCRIPTION
1. 가게 데이터 반환 시 storeId 포함하게 변경
2. 단골가게 데이터 반환 시 deletedAt이 null이 아닌 데이터는 제외하게 변경
3. user-checker middleware에서 token 관련 에러 발생 시 에러를 반환하는 게 아닌 다음 단계로 넘어가게 변경